### PR TITLE
Fix the config node role name in utils.rb

### DIFF
--- a/cookbooks/contrail/libraries/utils.rb
+++ b/cookbooks/contrail/libraries/utils.rb
@@ -28,7 +28,7 @@ end
 def get_config_nodes
     result = search(:node, "role:*config* AND chef_environment:#{node.chef_environment}")
     result.map! { |x| x['hostname'] == node['hostname'] ? node : x }
-    if not result.include?(node) and node.run_list.roles.include?('config')
+    if not result.include?(node) and node.run_list.roles.include?('contrail-config')
         result.push(node)
     end
     return result.sort! { |a, b| a['hostname'] <=> b['hostname'] }


### PR DESCRIPTION
Updated get_config_nodes() function to use the correct config node role
name.

Resolves Juniper/contrail-chef#1
