### PR TITLE
Use yum cookbook to define contrail repo

### DIFF
--- a/cookbooks/contrail/attributes/default.rb
+++ b/cookbooks/contrail/attributes/default.rb
@@ -18,6 +18,7 @@ default['contrail']['haproxy'] = true
 default['contrail']['cfgm']['hostname'] = "a6s35"
 default['contrail']['cfgm']['ip'] = "10.84.13.35"
 default['contrail']['region_name'] = "RegionOne"
+default['contrail']['yum_repo_url'] = "file:///opt/contrail/contrail_install_repo/"
 # Openstack
 default['contrail']['openstack']['ip'] = "10.84.13.35"
 default['contrail']['openstack_root_pw'] = "contrail123"

--- a/cookbooks/contrail/metadata.rb
+++ b/cookbooks/contrail/metadata.rb
@@ -4,4 +4,6 @@ maintainer_email 'praneetb@juniper.net'
 license          'All rights reserved'
 description      'Installs/Configures contrail'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'
+
+depends          'yum', '>= 3.0.0'

--- a/cookbooks/contrail/recipes/repo.rb
+++ b/cookbooks/contrail/recipes/repo.rb
@@ -5,9 +5,19 @@
 # Copyright 2014, Juniper Networks
 #
 
-if not platform?("ubuntu") then
-    template "/etc/yum.repos.d/contrail-install.repo" do
-        source "contrail-centos.repo.erb"
-        mode 00644
-    end
+# We're using yum-priorities to ensure packages in the contrail repo are used
+# over and above newer versions that may exist in other repos.
+package "yum-plugin-priorities" do
+  action :install
+end
+
+case node["platform_family"]
+when "rhel"
+  yum_repository "contrail" do
+    description "Contrail Packages"
+    baseurl node["contrail"]["yum_repo_url"]
+    gpgcheck false
+    priority "1"
+    action :create
+  end
 end

--- a/cookbooks/contrail/templates/default/contrail-centos.repo.erb
+++ b/cookbooks/contrail/templates/default/contrail-centos.repo.erb
@@ -1,6 +1,0 @@
-[contrail_install_repo]
-name=contrail_install_repo
-baseurl=file:///opt/contrail/contrail_install_repo/
-enabled=1
-priority=1
-gpgcheck=0


### PR DESCRIPTION
By using the yum cookbook we can provide the URL of the contrail repo as
an attribute.
