### PR TITLE
Add Berksfile to project

### DIFF
--- a/cookbooks/contrail/Berksfile
+++ b/cookbooks/contrail/Berksfile
@@ -1,0 +1,4 @@
+site :opscode
+
+metadata
+cookbook "yum", ">= 3.0.0"


### PR DESCRIPTION
We need a means of pulling in dependant cookbooks when writing chefspec
tests. Berkshelf is arguably the best option.
