### PR TITLE
Discover the OS Controller IP using search()

### DIFF
--- a/cookbooks/contrail/Berksfile
+++ b/cookbooks/contrail/Berksfile
@@ -1,0 +1,4 @@
+site :opscode
+
+metadata
+cookbook "yum", ">= 3.0.0"

--- a/cookbooks/contrail/attributes/default.rb
+++ b/cookbooks/contrail/attributes/default.rb
@@ -20,7 +20,7 @@ default['contrail']['cfgm']['ip'] = "10.84.13.35"
 default['contrail']['region_name'] = "RegionOne"
 default['contrail']['yum_repo_url'] = "file:///opt/contrail/contrail_install_repo/"
 # Openstack
-default['contrail']['openstack']['ip'] = "10.84.13.35"
+default['contrail']['openstack_controller_role'] = "contrail-openstack"
 default['contrail']['openstack_root_pw'] = "contrail123"
 # Keystone
 default['contrail']['keystone']['ip'] = "10.84.13.35"

--- a/cookbooks/contrail/libraries/utils.rb
+++ b/cookbooks/contrail/libraries/utils.rb
@@ -5,40 +5,62 @@
 # Copyright 2014, Juniper Networks
 #
 
-def get_all_roles_nodes
-    result = search(:node, "chef_environment:#{node.chef_environment}")
-    if result.any? { |x| x['hostname'] == node['hostname'] }
-        result.map! { |x| x['hostname'] == node['hostname'] ? node : x }
-    else
-        result.push(node)
-    end
-    return result.sort! { |a, b| a['hostname'] <=> b['hostname'] }
-end
+module ::Contrail
 
-def get_database_nodes
-    result = search(:node, "role:*contrail-database* AND chef_environment:#{node.chef_environment}")
-    result.map! { |x| x['hostname'] == node['hostname'] ? node : x }
-    if not result.include?(node) and node.run_list.roles.include?('contrail-database')
-        result.push(node)
-    end
-    result.each { |node| node.default['contrail']['node_number'] = "#{result.rindex(node)+1}" }
-    return result.sort! { |a, b| a['hostname'] <=> b['hostname'] }
-end
+  def get_all_roles_nodes
+      result = search(:node, "chef_environment:#{node.chef_environment}")
+      if result.any? { |x| x['hostname'] == node['hostname'] }
+          result.map! { |x| x['hostname'] == node['hostname'] ? node : x }
+      else
+          result.push(node)
+      end
+      return result.sort! { |a, b| a['hostname'] <=> b['hostname'] }
+  end
 
-def get_config_nodes
-    result = search(:node, "role:*config* AND chef_environment:#{node.chef_environment}")
-    result.map! { |x| x['hostname'] == node['hostname'] ? node : x }
-    if not result.include?(node) and node.run_list.roles.include?('contrail-config')
-        result.push(node)
-    end
-    return result.sort! { |a, b| a['hostname'] <=> b['hostname'] }
-end
+  def get_database_nodes
+      result = search(:node, "role:*contrail-database* AND chef_environment:#{node.chef_environment}")
+      result.map! { |x| x['hostname'] == node['hostname'] ? node : x }
+      if not result.include?(node) and node.run_list.roles.include?('contrail-database')
+          result.push(node)
+      end
+      result.each { |node| node.default['contrail']['node_number'] = "#{result.rindex(node)+1}" }
+      return result.sort! { |a, b| a['hostname'] <=> b['hostname'] }
+  end
 
-def get_compute_nodes
-    result = search(:node, "role:*compute* AND chef_environment:#{node.chef_environment}")
-    result.map! { |x| x['hostname'] == node['hostname'] ? node : x }
-    if not result.include?(node) and node.run_list.roles.include?('compute')
-        result.push(node)
+  def get_config_nodes
+      result = search(:node, "role:*config* AND chef_environment:#{node.chef_environment}")
+      result.map! { |x| x['hostname'] == node['hostname'] ? node : x }
+      if not result.include?(node) and node.run_list.roles.include?('contrail-config')
+          result.push(node)
+      end
+      return result.sort! { |a, b| a['hostname'] <=> b['hostname'] }
+  end
+
+  def get_compute_nodes
+      result = search(:node, "role:*compute* AND chef_environment:#{node.chef_environment}")
+      result.map! { |x| x['hostname'] == node['hostname'] ? node : x }
+      if not result.include?(node) and node.run_list.roles.include?('compute')
+          result.push(node)
+      end
+      return result.sort! { |a, b| a['hostname'] <=> b['hostname'] }
+  end
+
+  def search_for(role)
+    resp = search(:node, "roles:#{role} AND chef_environment:#{node.chef_environment}")
+    resp ? resp : []
+  end
+
+  def get_openstack_controller_nodes
+    search_for(node['contrail']['openstack_controller_role'])
+  end
+
+  def get_openstack_controller_node_ip
+    controller_nodes = get_openstack_controller_nodes
+    msg = "Can't find OpenStack controller node with role '#{node['contrail']['openstack_controller_role']}'"
+    if controller_nodes.length < 1
+      raise msg
     end
-    return result.sort! { |a, b| a['hostname'] <=> b['hostname'] }
+    controller_nodes.first["ipaddress"]
+  end
+
 end

--- a/cookbooks/contrail/recipes/analytics.rb
+++ b/cookbooks/contrail/recipes/analytics.rb
@@ -6,10 +6,16 @@
 # Copyright 2014, Juniper Networks
 #
 
+class ::Chef::Recipe
+  include ::Contrail
+end
+
 package "contrail-openstack-analytics" do
     action :upgrade
     notifies :stop, "service[supervisor-analytics]", :immediately
 end
+
+database_nodes = get_database_nodes
 
 %w{ analytics-api
     collector
@@ -20,7 +26,7 @@ end
         owner "contrail"
         group "contrail"
         mode 00640
-        variables(:servers => get_database_nodes)
+        variables(:servers => database_nodes)
         notifies :restart, "service[contrail-#{pkg}]", :immediately
     end
 end

--- a/cookbooks/contrail/recipes/cinder.rb
+++ b/cookbooks/contrail/recipes/cinder.rb
@@ -43,7 +43,7 @@ bash "cinder-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{node['contrail']['openstack']['ip']}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/compute.rb
+++ b/cookbooks/contrail/recipes/compute.rb
@@ -48,7 +48,7 @@ bash "compute-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{node['contrail']['openstack']['ip']}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/database.rb
+++ b/cookbooks/contrail/recipes/database.rb
@@ -5,6 +5,10 @@
 # Copyright 2014, Juniper Networks
 #
 
+class ::Chef::Recipe
+  include ::Contrail
+end
+
 package "contrail-openstack-database" do
     action :upgrade
     notifies :stop, "service[supervisor-database]", :immediately
@@ -23,10 +27,11 @@ bash "remove-initial-cassandra-data-dir" do
 end
 
 %w{cassandra-env.sh cassandra-rackdc.properties cassandra.yaml}.each do |file|
+    database_nodes = get_database_nodes
     template "/etc/cassandra/conf/#{file}" do
         source "#{file}.erb"
         mode 00644
-        variables(:servers => get_database_nodes)
+        variables(:servers => database_nodes)
         notifies :restart, "service[contrail-database]", :delayed
     end
 end

--- a/cookbooks/contrail/recipes/glance.rb
+++ b/cookbooks/contrail/recipes/glance.rb
@@ -30,7 +30,7 @@ bash "glance-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{node['contrail']['openstack']['ip']}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/haproxy.rb
+++ b/cookbooks/contrail/recipes/haproxy.rb
@@ -5,6 +5,10 @@
 # Copyright 2014, Juniper Networks
 #
 
+class ::Chef::Recipe
+  include ::Contrail
+end
+
 package "haproxy" do
     action :upgrade
 end
@@ -18,11 +22,13 @@ end
 #    not_if "grep -e '^ENABLED=1' /etc/default/haproxy"
 #end
 
+config_nodes = get_config_nodes
+
 template "/etc/haproxy/haproxy.cfg" do
     source "haproxy.cfg.erb"
     mode 00644
     variables(
-        :servers => get_config_nodes,
+        :servers => config_nodes,
     )
     notifies :restart, "service[haproxy]", :immediately
 end

--- a/cookbooks/contrail/recipes/heat.rb
+++ b/cookbooks/contrail/recipes/heat.rb
@@ -30,7 +30,7 @@ bash "heat-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{node['contrail']['openstack']['ip']}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/keystone.rb
+++ b/cookbooks/contrail/recipes/keystone.rb
@@ -40,7 +40,7 @@ bash "keystone-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{node['contrail']['openstack']['ip']}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/nova.rb
+++ b/cookbooks/contrail/recipes/nova.rb
@@ -52,7 +52,7 @@ bash "nova-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{node['contrail']['openstack']['ip']}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/webui.rb
+++ b/cookbooks/contrail/recipes/webui.rb
@@ -5,17 +5,25 @@
 # Copyright 2014, Juniper Networks
 #
 
+class ::Chef::Recipe
+  include ::Contrail
+end
+
 package "contrail-openstack-webui" do
     action :upgrade
     notifies :stop, "service[supervisor-webui]", :immediately
 end
+
+database_nodes = get_database_nodes
+openstack_controller_ip = get_openstack_controller_node_ip
 
 template "/etc/contrail/config.global.js" do
     source "contrail-config.global.js.erb"
     owner "contrail"
     group "contrail"
     mode 00640
-    variables(:servers => get_database_nodes)
+    variables(:servers                 => database_nodes,
+              :openstack_controller_ip => openstack_controller_ip)
     notifies :restart, "service[contrail-webui]", :immediately
     notifies :restart, "service[contrail-webui-middleware]", :immediately
 end

--- a/cookbooks/contrail/recipes/zookeeper.rb
+++ b/cookbooks/contrail/recipes/zookeeper.rb
@@ -5,14 +5,20 @@
 # Copyright 2014, Juniper Networks 
 #
 
+class ::Chef::Recipe
+  include ::Contrail
+end
+
 package "zookeeper" do
     action :upgrade
 end
 
+database_nodes = get_database_nodes
+
 template "/etc/zookeeper/conf/zoo.cfg" do
     source "zoo.cfg.erb"
     mode 00644
-    variables(:servers => get_database_nodes)
+    variables(:servers => database_nodes)
     notifies :restart, "service[zookeeper]", :immediately
 end
 

--- a/cookbooks/contrail/spec/spec_helper.rb
+++ b/cookbooks/contrail/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'chefspec'
+require 'chefspec/berkshelf'

--- a/cookbooks/contrail/spec/unit/utils_spec.rb
+++ b/cookbooks/contrail/spec/unit/utils_spec.rb
@@ -1,0 +1,65 @@
+# encoding: UTF-8
+require 'spec_helper'
+require ::File.join ::File.dirname(__FILE__), '..', '..', 'libraries', 'utils'
+
+describe 'contrail::default' do
+
+  describe 'Contrail Search' do
+    let(:runner) { ChefSpec::Runner.new }
+    let(:chef_run) do
+      node.set['contrail']['openstack_controller_role'] = 'os-controller-role'
+      runner.converge(described_recipe)
+    end
+    let(:node) { runner.node }
+    let(:subject) { Object.new.extend(Contrail) }
+
+    describe '#search_for' do
+      it 'returns the correct result' do
+        search_results = [
+          { 'hostname' => 'dummynode' }
+        ]
+        expect(subject).to receive(:node).and_return(chef_run.node)
+        expect(subject).to receive(:search)
+          .with(:node, 'roles:dummy-role AND chef_environment:_default')
+          .and_return(search_results)
+        resp = subject.search_for('dummy-role')
+        expect(resp.length).to eq (1)
+        expect(resp[0]['hostname']).to eq ('dummynode')
+      end
+
+      it 'always returns an empty list' do
+        expect(subject).to receive(:node).and_return(chef_run.node)
+        expect(subject).to receive(:search)
+          .with(:node, 'roles:simple-role AND chef_environment:_default')
+          .and_return(nil)
+        resp = subject.search_for('simple-role')
+        expect(resp).to eq ([])
+      end
+    end
+
+    describe '#openstack_controller_node_ip' do
+      it 'returns the correct IP address' do
+        search_results = [
+          { 'ipaddress' => '1.2.3.4' }
+        ]
+        expect(subject).to receive(:node).exactly(3).and_return(chef_run.node)
+        expect(subject).to receive(:search)
+          .with(:node, 'roles:os-controller-role AND chef_environment:_default')
+          .and_return(search_results)
+        resp = subject.get_openstack_controller_node_ip
+        expect(resp).to eq '1.2.3.4'
+      end
+
+      it 'raises an error when there are not OpenStack controller nodes' do
+        expect(subject).to receive(:node).exactly(2).and_return(chef_run.node)
+        expect(subject).to receive(:search)
+          .with(:node, 'roles:os-controller-role AND chef_environment:_default')
+          .and_return([])
+        expect { subject.get_openstack_controller_node_ip }.to raise_error
+      end
+
+    end
+
+  end
+
+end

--- a/cookbooks/contrail/templates/default/contrail-config.global.js.erb
+++ b/cookbooks/contrail/templates/default/contrail-config.global.js.erb
@@ -87,7 +87,7 @@ config.networkManager.strictSSL = false;
 config.networkManager.ca = '';
 
 config.imageManager = {};
-config.imageManager.ip = '<%=node['contrail']['openstack']['ip']%>';
+config.imageManager.ip = '<%= @openstack_controller_ip %>';
 config.imageManager.port = '9292';
 config.imageManager.authProtocol = 'http';
 config.imageManager.apiVersion = ['v1', 'v2'];
@@ -95,7 +95,7 @@ config.imageManager.strictSSL = false;
 config.imageManager.ca = '';
 
 config.computeManager = {};
-config.computeManager.ip = '<%=node['contrail']['openstack']['ip']%>';
+config.computeManager.ip = '<%= @openstack_controller_ip %>';
 config.computeManager.port = '8774';
 config.computeManager.authProtocol = 'http';
 config.computeManager.apiVersion = ['v1.1', 'v2'];
@@ -118,7 +118,7 @@ config.identityManager.strictSSL = false;
 config.identityManager.ca = '';
 
 config.storageManager = {};
-config.storageManager.ip = '<%=node['contrail']['openstack']['ip']%>';
+config.storageManager.ip = '<%= @openstack_controller_ip %>';
 config.storageManager.port = '8776';
 config.storageManager.authProtocol = 'http';
 config.storageManager.apiVersion = ['v1'];


### PR DESCRIPTION
The main thrust of this change is to discover the OpenStack controller
node's IP address at run time rather than using an attribute. This is
achieved by searching the chef server for a node with the OpenStack
controller role.

A few other changes are also included,
- Moved the functions in libraries/utils.rb into a module. This is
  considered safer than using the global scope. As well as modifying
  utils.rb this change also necessitated updating all recipes to include
  the new "Contrail" module.
- Added chefspec tests for the new methods that search for the OpenStack
  controller node.
