### PR TITLE
Remove static IP and hostname attributes

### DIFF
--- a/cookbooks/contrail/attributes/default.rb
+++ b/cookbooks/contrail/attributes/default.rb
@@ -15,8 +15,6 @@ default['contrail']['admin_password'] = "c0ntrail123"
 default['contrail']['admin_user'] = "admin"
 default['contrail']['admin_tenant_name'] = "admin"
 default['contrail']['haproxy'] = true
-default['contrail']['cfgm']['hostname'] = "a6s35"
-default['contrail']['cfgm']['ip'] = "10.84.13.35"
 default['contrail']['region_name'] = "RegionOne"
 default['contrail']['yum_repo_url'] = "file:///opt/contrail/contrail_install_repo/"
 # Openstack

--- a/cookbooks/contrail/attributes/default.rb
+++ b/cookbooks/contrail/attributes/default.rb
@@ -23,7 +23,6 @@ default['contrail']['yum_repo_url'] = "file:///opt/contrail/contrail_install_rep
 default['contrail']['openstack_controller_role'] = "contrail-openstack"
 default['contrail']['openstack_root_pw'] = "contrail123"
 # Keystone
-default['contrail']['keystone']['ip'] = "10.84.13.35"
 default['contrail']['protocol']['keystone'] = "http"
 #Database
 default['contrail']['database']['ip'] = "10.84.13.35"

--- a/cookbooks/contrail/attributes/default.rb
+++ b/cookbooks/contrail/attributes/default.rb
@@ -26,8 +26,6 @@ default['contrail']['openstack_root_pw'] = "contrail123"
 default['contrail']['protocol']['keystone'] = "http"
 # Control
 default['contrail']['controller_role'] = "contrail-control"
-# Analytics
-default['contrail']['analytics']['ip'] = "10.84.13.35"
 # Compute
 default['contrail']['compute']['interface'] = "eth1"
 default['contrail']['compute']['hostname'] = "a6s35"

--- a/cookbooks/contrail/attributes/default.rb
+++ b/cookbooks/contrail/attributes/default.rb
@@ -24,8 +24,6 @@ default['contrail']['openstack_controller_role'] = "contrail-openstack"
 default['contrail']['openstack_root_pw'] = "contrail123"
 # Keystone
 default['contrail']['protocol']['keystone'] = "http"
-#Database
-default['contrail']['database']['ip'] = "10.84.13.35"
 # Control
 default['contrail']['control']['ip'] = "10.84.13.35"
 default['contrail']['control']['hostname'] = "a6s35"

--- a/cookbooks/contrail/attributes/default.rb
+++ b/cookbooks/contrail/attributes/default.rb
@@ -25,8 +25,7 @@ default['contrail']['openstack_root_pw'] = "contrail123"
 # Keystone
 default['contrail']['protocol']['keystone'] = "http"
 # Control
-default['contrail']['control']['ip'] = "10.84.13.35"
-default['contrail']['control']['hostname'] = "a6s35"
+default['contrail']['controller_role'] = "contrail-control"
 # Analytics
 default['contrail']['analytics']['ip'] = "10.84.13.35"
 # Compute

--- a/cookbooks/contrail/libraries/utils.rb
+++ b/cookbooks/contrail/libraries/utils.rb
@@ -50,13 +50,18 @@ module ::Contrail
     resp ? resp : []
   end
 
-  def get_openstack_controller_nodes
-    search_for(node['contrail']['openstack_controller_role'])
+  def get_openstack_controller_node_ip
+    controller_nodes = search_for(node['contrail']['openstack_controller_role'])
+    msg = "Can't find OpenStack controller node with role '#{node['contrail']['openstack_controller_role']}'"
+    if controller_nodes.length < 1
+      raise msg
+    end
+    controller_nodes.first["ipaddress"]
   end
 
-  def get_openstack_controller_node_ip
-    controller_nodes = get_openstack_controller_nodes
-    msg = "Can't find OpenStack controller node with role '#{node['contrail']['openstack_controller_role']}'"
+  def get_contrail_controller_node_ip
+    controller_nodes = search_for(node['contrail']['controller_role'])
+    msg = "Can't find Contrail controller node with role '#{node['contrail']['controller_role']}'"
     if controller_nodes.length < 1
       raise msg
     end

--- a/cookbooks/contrail/metadata.rb
+++ b/cookbooks/contrail/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'praneetb@juniper.net'
 license          'All rights reserved'
 description      'Installs/Configures contrail'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '0.3.0'
 
 depends          'yum', '>= 3.0.0'

--- a/cookbooks/contrail/metadata.rb
+++ b/cookbooks/contrail/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'praneetb@juniper.net'
 license          'All rights reserved'
 description      'Installs/Configures contrail'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.0'
+version          '0.4.0'
 
 depends          'yum', '>= 3.0.0'

--- a/cookbooks/contrail/metadata.rb
+++ b/cookbooks/contrail/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'praneetb@juniper.net'
 license          'All rights reserved'
 description      'Installs/Configures contrail'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.0'
+version          '0.3.0'
 
 depends          'yum', '>= 3.0.0'

--- a/cookbooks/contrail/recipes/cfgm.rb
+++ b/cookbooks/contrail/recipes/cfgm.rb
@@ -142,9 +142,9 @@ bash "provision_control" do
     admin_password=node['contrail']['admin_password']
     admin_tenant_name=node['contrail']['admin_tenant_name']
     cfgm_ip=node['contrail']['cfgm']['ip']
-    ctrl_ip=node['contrail']['control']['ip']
+    ctrl_ip=node['ipaddress']
     asn=node['contrail']['router_asn']
-    hostname=node['contrail']['control']['hostname']
+    hostname=node['hostname']
     code <<-EOH
         python /opt/contrail/utils/provision_control.py \
             --admin_user #{admin_user} \

--- a/cookbooks/contrail/recipes/cfgm.rb
+++ b/cookbooks/contrail/recipes/cfgm.rb
@@ -121,7 +121,7 @@ bash "provision_metadata_services" do
     admin_user=node['contrail']['admin_user']
     admin_password=node['contrail']['admin_password']
     admin_tenant_name=node['contrail']['admin_tenant_name']
-    cfgm_ip=node['contrail']['cfgm']['ip']
+    cfgm_ip=node['ipaddress']
     code <<-EOH
         python /opt/contrail/utils/provision_linklocal.py \
             --admin_user #{admin_user} \
@@ -141,7 +141,7 @@ bash "provision_control" do
     admin_user=node['contrail']['admin_user']
     admin_password=node['contrail']['admin_password']
     admin_tenant_name=node['contrail']['admin_tenant_name']
-    cfgm_ip=node['contrail']['cfgm']['ip']
+    cfgm_ip=node['ipaddress']
     ctrl_ip=node['ipaddress']
     asn=node['contrail']['router_asn']
     hostname=node['hostname']
@@ -180,7 +180,7 @@ get_compute_nodes.each do |server|
         admin_tenant_name=node['contrail']['admin_tenant_name']
         hostname=server['hostname']
         hostip=server['ipaddress']
-        cfgm_ip=node['contrail']['cfgm']['ip']
+        cfgm_ip=node['ipaddress']
         openstack_ip=get_openstack_controller_node_ip
         code <<-EOH
             python /opt/contrail/utils/provision_vrouter.py \

--- a/cookbooks/contrail/recipes/cfgm.rb
+++ b/cookbooks/contrail/recipes/cfgm.rb
@@ -177,7 +177,7 @@ get_compute_nodes.each do |server|
         hostname=server['hostname']
         hostip=server['ipaddress']
         cfgm_ip=node['contrail']['cfgm']['ip']
-        openstack_ip=openstack_controller_node_ip
+        openstack_ip=get_openstack_controller_node_ip
         code <<-EOH
             python /opt/contrail/utils/provision_vrouter.py \
                 --admin_user #{admin_user} \

--- a/cookbooks/contrail/recipes/cfgm.rb
+++ b/cookbooks/contrail/recipes/cfgm.rb
@@ -74,11 +74,14 @@ template "/etc/ifmap-server/basicauthusers.properties" do
     #notifies :restart, "service[ifmap]", :immediately
 end
 
+openstack_controller_node_ip = get_openstack_controller_node_ip
+
 template "/etc/contrail/vnc_api_lib.ini" do
     source "contrail-vnc_api_lib.ini.erb"
     owner "contrail"
     group "contrail"
     mode 00644
+    variables(:keystone_server_ip => openstack_controller_node_ip)
 end
 
 database_nodes = get_database_nodes
@@ -93,7 +96,8 @@ database_nodes = get_database_nodes
         owner "contrail"
         group "contrail"
         mode 00640
-        variables(:servers => database_nodes)
+        variables(:servers            => database_nodes,
+                  :keystone_server_ip => openstack_controller_node_ip)
         notifies :restart, "service[#{pkg}]", :immediately
     end
 end

--- a/cookbooks/contrail/recipes/cinder.rb
+++ b/cookbooks/contrail/recipes/cinder.rb
@@ -43,7 +43,7 @@ bash "cinder-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{get_openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/cinder.rb
+++ b/cookbooks/contrail/recipes/cinder.rb
@@ -34,6 +34,8 @@ end
     end
 end
 
+openstack_controller_node_ip = get_openstack_controller_node_ip
+
 bash "cinder-server-setup" do
     user  "root"
     code <<-EOC
@@ -42,8 +44,8 @@ bash "cinder-server-setup" do
         echo "AUTH_PROTOCOL=#{node['contrail']['protocol']['keystone']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{get_openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/cinder.rb
+++ b/cookbooks/contrail/recipes/cinder.rb
@@ -46,11 +46,11 @@ bash "cinder-server-setup" do
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
-        echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "QUANTUM=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details
         echo "COMPUTE=#{node['contrail']['compute']['ip']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER_MGMT=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER_MGMT=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         /usr/bin/cinder-server-setup.sh
     EOC
 end

--- a/cookbooks/contrail/recipes/compute.rb
+++ b/cookbooks/contrail/recipes/compute.rb
@@ -51,11 +51,11 @@ bash "compute-server-setup" do
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
-        echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "QUANTUM=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details
         echo "COMPUTE=#{node['contrail']['compute']['ip']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER_MGMT=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER_MGMT=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         /usr/bin/compute-server-setup.sh
     EOC
 end

--- a/cookbooks/contrail/recipes/compute.rb
+++ b/cookbooks/contrail/recipes/compute.rb
@@ -48,7 +48,7 @@ bash "compute-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{get_openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/compute.rb
+++ b/cookbooks/contrail/recipes/compute.rb
@@ -39,6 +39,8 @@ service "messagebus" do
     action [:enable, :start]
 end
 
+openstack_controller_node_ip = get_openstack_controller_node_ip
+
 bash "compute-server-setup" do
     user  "root"
     code <<-EOC
@@ -47,8 +49,8 @@ bash "compute-server-setup" do
         echo "AUTH_PROTOCOL=#{node['contrail']['protocol']['keystone']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{get_openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/glance.rb
+++ b/cookbooks/contrail/recipes/glance.rb
@@ -33,11 +33,11 @@ bash "glance-server-setup" do
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
-        echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "QUANTUM=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details
         echo "COMPUTE=#{node['contrail']['compute']['ip']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER_MGMT=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER_MGMT=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         /usr/bin/glance-server-setup.sh
     EOC
 end

--- a/cookbooks/contrail/recipes/glance.rb
+++ b/cookbooks/contrail/recipes/glance.rb
@@ -30,7 +30,7 @@ bash "glance-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{get_openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/glance.rb
+++ b/cookbooks/contrail/recipes/glance.rb
@@ -21,6 +21,8 @@ end
     end
 end
 
+openstack_controller_node_ip = get_openstack_controller_node_ip
+
 bash "glance-server-setup" do
     user  "root"
     code <<-EOC
@@ -29,8 +31,8 @@ bash "glance-server-setup" do
         echo "AUTH_PROTOCOL=#{node['contrail']['protocol']['keystone']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{get_openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/heat.rb
+++ b/cookbooks/contrail/recipes/heat.rb
@@ -21,6 +21,8 @@ end
     end
 end
 
+openstack_controller_node_ip = get_openstack_controller_node_ip
+
 bash "heat-server-setup" do
     user  "root"
     code <<-EOC
@@ -29,8 +31,8 @@ bash "heat-server-setup" do
         echo "AUTH_PROTOCOL=#{node['contrail']['protocol']['keystone']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{get_openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/heat.rb
+++ b/cookbooks/contrail/recipes/heat.rb
@@ -33,11 +33,11 @@ bash "heat-server-setup" do
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
-        echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "QUANTUM=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details
         echo "COMPUTE=#{node['contrail']['compute']['ip']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER_MGMT=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER_MGMT=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         /usr/bin/heat-server-setup.sh
     EOC
 end

--- a/cookbooks/contrail/recipes/heat.rb
+++ b/cookbooks/contrail/recipes/heat.rb
@@ -30,7 +30,7 @@ bash "heat-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{get_openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/keystone.rb
+++ b/cookbooks/contrail/recipes/keystone.rb
@@ -31,6 +31,8 @@ service "keystone" do
     action [:enable, :start]
 end
 
+openstack_controller_node_ip = get_openstack_controller_node_ip
+
 bash "keystone-server-setup" do
     user  "root"
     code <<-EOC
@@ -39,8 +41,8 @@ bash "keystone-server-setup" do
         echo "AUTH_PROTOCOL=#{node['contrail']['protocol']['keystone']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{get_openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/keystone.rb
+++ b/cookbooks/contrail/recipes/keystone.rb
@@ -43,11 +43,11 @@ bash "keystone-server-setup" do
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
-        echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "QUANTUM=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details
         echo "COMPUTE=#{node['contrail']['compute']['ip']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER_MGMT=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER_MGMT=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         /usr/bin/keystone-server-setup.sh
     EOC
 #    not_if { ::File.exists?("/etc/contrail/ctrl-details") }

--- a/cookbooks/contrail/recipes/keystone.rb
+++ b/cookbooks/contrail/recipes/keystone.rb
@@ -40,7 +40,7 @@ bash "keystone-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{get_openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/neutron.rb
+++ b/cookbooks/contrail/recipes/neutron.rb
@@ -47,11 +47,11 @@ bash "neutron-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
-        echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
+        echo "QUANTUM=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=#{quantum_port}" >> /etc/contrail/ctrl-details
         echo "COMPUTE=#{node['contrail']['compute']['ip']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER_MGMT=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER_MGMT=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         /usr/bin/quantum-server-setup.sh
     EOC
 #    not_if { ::File.exists?("/etc/contrail/ctrl-details") }
@@ -64,7 +64,7 @@ if node['contrail']['manage_neutron'] then
         region=node['contrail']['region_name']
         ks_server_ip=openstack_controller_node_ip
         region=node['contrail']['region_name']
-        quant_server_ip=node['contrail']['cfgm']['ip']
+        quant_server_ip=node['ipaddress']
         admin_user=node['contrail']['admin_user']
         admin_password=node['contrail']['admin_password']
         admin_tenant_name=node['contrail']['admin_tenant_name']

--- a/cookbooks/contrail/recipes/neutron.rb
+++ b/cookbooks/contrail/recipes/neutron.rb
@@ -5,6 +5,10 @@
 # Copyright 2014, Juniper Networks
 #
 
+class ::Chef::Recipe
+  include ::Contrail
+end
+
 %w{ openstack-neutron
     neutron-plugin-contrail
     python-simplejson

--- a/cookbooks/contrail/recipes/neutron.rb
+++ b/cookbooks/contrail/recipes/neutron.rb
@@ -27,6 +27,8 @@ template "/etc/neutron/plugin.ini" do
     notifies :restart, "service[neutron-server]", :immediately
 end
 
+openstack_controller_node_ip = get_openstack_controller_node_ip
+
 bash "neutron-server-setup" do
     user  "root"
     if node['contrail']['haproxy'] then
@@ -40,7 +42,7 @@ bash "neutron-server-setup" do
         echo "AUTH_PROTOCOL=#{node['contrail']['protocol']['keystone']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "AMQP_SERVER=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=#{quantum_port}" >> /etc/contrail/ctrl-details
@@ -56,7 +58,7 @@ if node['contrail']['manage_neutron'] then
     bash "neutron-endpoint-setup" do
         user  "root"
         region=node['contrail']['region_name']
-        ks_server_ip=node['contrail']['keystone']['ip']
+        ks_server_ip=openstack_controller_node_ip
         region=node['contrail']['region_name']
         quant_server_ip=node['contrail']['cfgm']['ip']
         admin_user=node['contrail']['admin_user']

--- a/cookbooks/contrail/recipes/nova.rb
+++ b/cookbooks/contrail/recipes/nova.rb
@@ -43,6 +43,8 @@ bash "nova-params-setup" do
     EOC
 end
 
+openstack_controller_node_ip = get_openstack_controller_node_ip
+
 bash "nova-server-setup" do
     user  "root"
     code <<-EOC
@@ -51,8 +53,8 @@ bash "nova-server-setup" do
         echo "AUTH_PROTOCOL=#{node['contrail']['protocol']['keystone']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{get_openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/nova.rb
+++ b/cookbooks/contrail/recipes/nova.rb
@@ -52,7 +52,7 @@ bash "nova-server-setup" do
         echo "QUANTUM_PROTOCOL=http" >> /etc/contrail/ctrl-details
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{node['contrail']['keystone']['ip']}" >> /etc/contrail/ctrl-details
-        echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
+        echo "AMQP_SERVER=#{get_openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details

--- a/cookbooks/contrail/recipes/nova.rb
+++ b/cookbooks/contrail/recipes/nova.rb
@@ -55,11 +55,11 @@ bash "nova-server-setup" do
         echo "ADMIN_TOKEN=#{node['contrail']['admin_token']}" >> /etc/contrail/ctrl-details
         echo "CONTROLLER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
         echo "AMQP_SERVER=#{openstack_controller_node_ip}" >> /etc/contrail/ctrl-details
-        echo "QUANTUM=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "QUANTUM=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         echo "QUANTUM_PORT=9696" >> /etc/contrail/ctrl-details
         echo "OPENSTACK_INDEX=1" >> /etc/contrail/ctrl-details
         echo "COMPUTE=#{node['contrail']['compute']['ip']}" >> /etc/contrail/ctrl-details
-        echo "CONTROLLER_MGMT=#{node['contrail']['cfgm']['ip']}" >> /etc/contrail/ctrl-details
+        echo "CONTROLLER_MGMT=#{node['ipaddress']}" >> /etc/contrail/ctrl-details
         /usr/bin/nova-server-setup.sh
     EOC
 end

--- a/cookbooks/contrail/spec/unit/utils_spec.rb
+++ b/cookbooks/contrail/spec/unit/utils_spec.rb
@@ -37,7 +37,7 @@ describe 'contrail::default' do
       end
     end
 
-    describe '#openstack_controller_node_ip' do
+    describe '#get_openstack_controller_node_ip' do
       it 'returns the correct IP address' do
         search_results = [
           { 'ipaddress' => '1.2.3.4' }

--- a/cookbooks/contrail/spec/unit/utils_spec.rb
+++ b/cookbooks/contrail/spec/unit/utils_spec.rb
@@ -6,19 +6,19 @@ describe 'contrail::default' do
 
   describe 'Contrail Search' do
     let(:runner) { ChefSpec::Runner.new }
-    let(:chef_run) do
-      node.set['contrail']['openstack_controller_role'] = 'os-controller-role'
-      runner.converge(described_recipe)
-    end
-    let(:node) { runner.node }
+    let(:chef_run) { runner.converge(described_recipe) }
     let(:subject) { Object.new.extend(Contrail) }
+    let(:node) { runner.node }
+
+    before do
+      allow(subject).to receive(:node).and_return(chef_run.node)
+    end
 
     describe '#search_for' do
       it 'returns the correct result' do
         search_results = [
           { 'hostname' => 'dummynode' }
         ]
-        expect(subject).to receive(:node).and_return(chef_run.node)
         expect(subject).to receive(:search)
           .with(:node, 'roles:dummy-role AND chef_environment:_default')
           .and_return(search_results)
@@ -28,7 +28,6 @@ describe 'contrail::default' do
       end
 
       it 'always returns an empty list' do
-        expect(subject).to receive(:node).and_return(chef_run.node)
         expect(subject).to receive(:search)
           .with(:node, 'roles:simple-role AND chef_environment:_default')
           .and_return(nil)
@@ -42,22 +41,36 @@ describe 'contrail::default' do
         search_results = [
           { 'ipaddress' => '1.2.3.4' }
         ]
-        expect(subject).to receive(:node).exactly(3).and_return(chef_run.node)
         expect(subject).to receive(:search)
-          .with(:node, 'roles:os-controller-role AND chef_environment:_default')
+          .with(:node, 'roles:contrail-openstack AND chef_environment:_default')
           .and_return(search_results)
         resp = subject.get_openstack_controller_node_ip
         expect(resp).to eq '1.2.3.4'
       end
 
-      it 'raises an error when there are not OpenStack controller nodes' do
-        expect(subject).to receive(:node).exactly(2).and_return(chef_run.node)
+      it 'raises an error when there are no OpenStack controller nodes' do
         expect(subject).to receive(:search)
-          .with(:node, 'roles:os-controller-role AND chef_environment:_default')
+          .with(:node, 'roles:contrail-openstack AND chef_environment:_default')
           .and_return([])
         expect { subject.get_openstack_controller_node_ip }.to raise_error
       end
+    end
 
+    describe '#get_contrail_controller_node_ip' do
+      it 'returns the correct IP address' do
+        expect(subject).to receive(:search)
+          .with(:node, 'roles:contrail-control AND chef_environment:_default')
+          .and_return([ {'ipaddress' => '5.6.7.8'} ])
+        resp = subject.get_contrail_controller_node_ip
+        expect(resp).to eq '5.6.7.8'
+      end
+
+      it 'raises an error when there are no Contrail controller nodes' do
+        expect(subject).to receive(:search)
+          .with(:node, 'roles:contrail-control AND chef_environment:_default')
+          .and_return([])
+        expect { subject.get_contrail_controller_node_ip }.to raise_error
+      end
     end
 
   end

--- a/cookbooks/contrail/templates/default/cassandra.yaml.erb
+++ b/cookbooks/contrail/templates/default/cassandra.yaml.erb
@@ -238,7 +238,7 @@ seed_provider:
           # seeds is actually a comma-delimited list of addresses.
           # Ex: "<ip1>,<ip2>,<ip3>"
 <% if @servers.length > 1 then @servers.delete(node) end -%>
-          - seeds: "<%= @servers.collect{|x| x['contrail']['database']['ip']}.join(',') %>"
+          - seeds: "<%= @servers.collect{|x| x['ipaddress']}.join(',') %>"
 
 # emergency pressure valve: each time heap usage after a full (CMS)
 # garbage collection is above this fraction of the max, Cassandra will
@@ -329,7 +329,7 @@ ssl_storage_port: 7001
 # address associated with the hostname (it might not be).
 #
 # Setting this to 0.0.0.0 is always wrong.
-listen_address: <%=node['contrail']['database']['ip']%>
+listen_address: <%=node['ipaddress']%>
 
 # Address to broadcast to other Cassandra nodes
 # Leaving this blank will set it to the same value as listen_address
@@ -365,7 +365,7 @@ start_rpc: true
 # Note that unlike ListenAddress above, it is allowed to specify 0.0.0.0
 # here if you want to listen on all interfaces, but that will break clients
 # that rely on node auto-discovery.
-rpc_address: <%=node['contrail']['database']['ip']%>
+rpc_address: <%=node['ipaddress']%>
 # port for Thrift to listen for clients on
 rpc_port: 9160
 

--- a/cookbooks/contrail/templates/default/contrail-analytics-api.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-analytics-api.conf.erb
@@ -17,7 +17,7 @@ log_category =
 log_file = /var/log/contrail/contrail-analytics-api.log
 
 [DISCOVERY]
-disc_server_ip = <%=node['contrail']['cfgm']['ip']%>
+disc_server_ip = <%=node['ipaddress']%>
 disc_server_port = 5998
 
 [REDIS]

--- a/cookbooks/contrail/templates/default/contrail-analytics-api.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-analytics-api.conf.erb
@@ -5,7 +5,7 @@
 ################################################
 
 [DEFAULTS]
-host_ip = <%=node['contrail']['analytics']['ip']%>
+host_ip = <%=node['ipaddress']%>
 cassandra_server_list = <%= @servers.collect{|x| x['ipaddress']+':9160'}.join(' ') %>
 collectors = 127.0.0.1:8086
 http_server_port = 8090

--- a/cookbooks/contrail/templates/default/contrail-analytics-api.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-analytics-api.conf.erb
@@ -6,7 +6,7 @@
 
 [DEFAULTS]
 host_ip = <%=node['contrail']['analytics']['ip']%>
-cassandra_server_list = <%= @servers.collect{|x| x['contrail']['database']['ip']+':9160'}.join(' ') %>
+cassandra_server_list = <%= @servers.collect{|x| x['ipaddress']+':9160'}.join(' ') %>
 collectors = 127.0.0.1:8086
 http_server_port = 8090
 rest_api_port = 8081

--- a/cookbooks/contrail/templates/default/contrail-api.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-api.conf.erb
@@ -9,7 +9,7 @@ ifmap_server_ip = <%=node['contrail']['cfgm']['ip']%>
 ifmap_server_port = 8445
 ifmap_username = api-server
 ifmap_password = api-server
-cassandra_server_list = <%= @servers.collect{|x| x['contrail']['database']['ip']+':9160'}.join(' ') %>
+cassandra_server_list = <%= @servers.collect{|x| x['ipaddress']+':9160'}.join(' ') %>
 listen_ip_addr=0.0.0.0
 listen_port=8082
 multi_tenancy=<%=node['contrail']['multi_tenancy']%>
@@ -18,7 +18,7 @@ log_local=1
 log_level=SYS_NOTICE
 disc_server_ip=<%=node['contrail']['cfgm']['ip']%>
 disc_server_port=5998
-zk_server_ip = <%= @servers.collect{|x| x['contrail']['database']['ip']+':2181'}.join(',') %>
+zk_server_ip = <%= @servers.collect{|x| x['ipaddress']+':2181'}.join(',') %>
 redis_server_ip=<%=node['contrail']['analytics']['ip']%>
 rabbit_server=<%=node['contrail']['cfgm']['ip']%>
 rabbit_port=5672

--- a/cookbooks/contrail/templates/default/contrail-api.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-api.conf.erb
@@ -19,7 +19,7 @@ log_level=SYS_NOTICE
 disc_server_ip=<%=node['contrail']['cfgm']['ip']%>
 disc_server_port=5998
 zk_server_ip = <%= @servers.collect{|x| x['ipaddress']+':2181'}.join(',') %>
-redis_server_ip=<%=node['contrail']['analytics']['ip']%>
+redis_server_ip=<%=node['ipaddress']%>
 rabbit_server=<%=node['contrail']['cfgm']['ip']%>
 rabbit_port=5672
 auth = keystone

--- a/cookbooks/contrail/templates/default/contrail-api.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-api.conf.erb
@@ -31,7 +31,7 @@ certfile=/etc/contrail/ssl/certs/apiserver.pem
 ca_certs=/etc/contrail/ssl/certs/ca.pem
 
 [KEYSTONE]
-auth_host=<%=node['contrail']['keystone']['ip']%>
+auth_host=<%= @keystone_server_ip %>
 auth_protocol=<%=node['contrail']['protocol']['keystone']%>
 auth_port=35357
 admin_user=<%=node['contrail']['admin_user']%>

--- a/cookbooks/contrail/templates/default/contrail-api.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-api.conf.erb
@@ -5,7 +5,7 @@
 ################################################
 
 [DEFAULTS]
-ifmap_server_ip = <%=node['contrail']['cfgm']['ip']%>
+ifmap_server_ip = <%=node['ipaddress']%>
 ifmap_server_port = 8445
 ifmap_username = api-server
 ifmap_password = api-server
@@ -16,11 +16,11 @@ multi_tenancy=<%=node['contrail']['multi_tenancy']%>
 log_file=/var/log/contrail/contrail-api.log
 log_local=1
 log_level=SYS_NOTICE
-disc_server_ip=<%=node['contrail']['cfgm']['ip']%>
+disc_server_ip=<%=node['ipaddress']%>
 disc_server_port=5998
 zk_server_ip = <%= @servers.collect{|x| x['ipaddress']+':2181'}.join(',') %>
 redis_server_ip=<%=node['ipaddress']%>
-rabbit_server=<%=node['contrail']['cfgm']['ip']%>
+rabbit_server=<%=node['ipaddress']%>
 rabbit_port=5672
 auth = keystone
 

--- a/cookbooks/contrail/templates/default/contrail-collector.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-collector.conf.erb
@@ -66,7 +66,7 @@ log_local=1
 # port=5998
 
 # IP address of discovery server
-server = <%=node['contrail']['cfgm']['ip']%>
+server = <%=node['ipaddress']%>
 
 [REDIS]
 # Port to connect to for communicating with redis-server

--- a/cookbooks/contrail/templates/default/contrail-collector.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-collector.conf.erb
@@ -12,7 +12,7 @@
 
 # IP address and port to be used to connect to cassandra.
 # Multiple IP:port strings separated by space can be provided
-cassandra_server_list = <%= @servers.collect{|x| x['contrail']['database']['ip']+':9160'}.join(' ') %>
+cassandra_server_list = <%= @servers.collect{|x| x['ipaddress']+':9160'}.join(' ') %>
 
 # IP address of analytics node. Resolved IP of 'hostname'
 hostip = <%=node['contrail']['analytics']['ip']%>

--- a/cookbooks/contrail/templates/default/contrail-collector.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-collector.conf.erb
@@ -15,7 +15,7 @@
 cassandra_server_list = <%= @servers.collect{|x| x['ipaddress']+':9160'}.join(' ') %>
 
 # IP address of analytics node. Resolved IP of 'hostname'
-hostip = <%=node['contrail']['analytics']['ip']%>
+hostip = <%=node['ipaddress']%>
 
 # Hostname of analytics node. If this is not configured value from ostname# will be taken
 # hostname=

--- a/cookbooks/contrail/templates/default/contrail-config.global.js.erb
+++ b/cookbooks/contrail/templates/default/contrail-config.global.js.erb
@@ -172,7 +172,7 @@ config.files.download_path = '/tmp';
 
 /* Cassandra Server */
 config.cassandra = {};
-config.cassandra.server_ips = [<%= @servers.collect{|x| '\''+x['contrail']['database']['ip']+'\''}.join(',') %>];
+config.cassandra.server_ips = [<%= @servers.collect{|x| '\''+x['ipaddress']+'\''}.join(',') %>];
 config.cassandra.server_port = '9160';
 config.cassandra.enable_edit = false;
 

--- a/cookbooks/contrail/templates/default/contrail-config.global.js.erb
+++ b/cookbooks/contrail/templates/default/contrail-config.global.js.erb
@@ -135,7 +135,7 @@ config.cnfg.ca = '';
 
 // Analytics API server and port.
 config.analytics = {};
-config.analytics.server_ip = '<%=node['contrail']['analytics']['ip']%>';
+config.analytics.server_ip = '<%=node['ipaddress']%>';
 config.analytics.server_port = '8081';
 config.analytics.authProtocol = 'http';
 config.analytics.strictSSL = false;
@@ -210,7 +210,7 @@ config.redisDBIndex = 1;
 
 /* WebUI Redis Server */
 config.redis_server_port = '6379';
-config.redis_server_ip = '<%=node['contrail']['analytics']['ip']%>';
+config.redis_server_ip = '<%=node['ipaddress']%>';
 config.redis_dump_file = '/var/lib/redis/dump-webui.rdb';
 
 /* Logo File: Use complete path of logo file location */

--- a/cookbooks/contrail/templates/default/contrail-config.global.js.erb
+++ b/cookbooks/contrail/templates/default/contrail-config.global.js.erb
@@ -103,7 +103,7 @@ config.computeManager.strictSSL = false;
 config.computeManager.ca = '';
 
 config.identityManager = {};
-config.identityManager.ip = '<%=node['contrail']['keystone']['ip']%>';
+config.identityManager.ip = '<%= @openstack_controller_ip %>';
 config.identityManager.port = '5000';
 config.identityManager.authProtocol = '<%=node['contrail']['protocol']['keystone']%>';
 /******************************************************************************

--- a/cookbooks/contrail/templates/default/contrail-config.global.js.erb
+++ b/cookbooks/contrail/templates/default/contrail-config.global.js.erb
@@ -79,7 +79,7 @@ config.serviceEndPointTakePublicURL = true;
  *      if you do not want to specify then use ''
 *****************************************************************************/
 config.networkManager = {};
-config.networkManager.ip = '<%=node['contrail']['cfgm']['ip']%>';
+config.networkManager.ip = '<%=node['ipaddress']%>';
 config.networkManager.port = '9696'
 config.networkManager.authProtocol = 'http';
 config.networkManager.apiVersion = [];
@@ -127,7 +127,7 @@ config.storageManager.ca = '';
 
 // VNConfig API server and port.
 config.cnfg = {};
-config.cnfg.server_ip = '<%=node['contrail']['cfgm']['ip']%>';
+config.cnfg.server_ip = '<%=node['ipaddress']%>';
 config.cnfg.server_port = '8082';
 config.cnfg.authProtocol = 'http';
 config.cnfg.strictSSL = false;
@@ -154,7 +154,7 @@ config.vcenter.wsdl = '/usr/src/contrail/contrail-web-core/webroot/js/vim.wsdl';
 
 /* Discovery Service */
 config.discoveryService = {};
-config.discoveryService.server_ip = '<%=node['contrail']['cfgm']['ip']%>';
+config.discoveryService.server_ip = '<%=node['ipaddress']%>';
 config.discoveryService.server_port = '5998';
 /* Specifiy true if subscription to discovery server should be enabled, else
  * specify false. Other than true/false value here is treated as true

--- a/cookbooks/contrail/templates/default/contrail-control.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-control.conf.erb
@@ -23,7 +23,7 @@ hostip = <%= node['ipaddress'] %>
 # xmpp_server_port=5269
 
 [DISCOVERY]
-server =  <%=node['contrail']['cfgm']['ip']%>
+server =  <%=node['ipaddress']%>
 #port = 5998
 
 [IFMAP]

--- a/cookbooks/contrail/templates/default/contrail-control.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-control.conf.erb
@@ -9,7 +9,7 @@ log_file = /var/log/contrail/contrail-control.log
 # bgp_config_file=bgp_config.xml
 # bgp_port=179
 # collectors= # Provided by discovery server
-hostip = <%=node['contrail']['control']['ip']%>
+hostip = <%= node['ipaddress'] %>
 # hostname= # Retrieved as `hostname`
 # http_server_port=8083
 # log_category=
@@ -28,5 +28,5 @@ server =  <%=node['contrail']['cfgm']['ip']%>
 
 [IFMAP]
 certs_store=
-user = <%=node['contrail']['control']['ip']%>
-password = <%=node['contrail']['control']['ip']%>
+user = <%= node['ipaddress'] %>
+password = <%= node['ipaddress'] %>

--- a/cookbooks/contrail/templates/default/contrail-discovery.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-discovery.conf.erb
@@ -7,7 +7,7 @@
 [DEFAULTS]
 zk_server_ip=<%= @servers.collect{|x| x['ipaddress']}.join(',') %>
 zk_server_port=2181
-listen_ip_addr=<%=node['contrail']['cfgm']['ip']%>
+listen_ip_addr=<%=node['ipaddress']%>
 listen_port=5998
 log_local=True
 log_file=/var/log/contrail/discovery.log

--- a/cookbooks/contrail/templates/default/contrail-discovery.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-discovery.conf.erb
@@ -5,13 +5,13 @@
 ################################################
 
 [DEFAULTS]
-zk_server_ip=<%= @servers.collect{|x| x['contrail']['database']['ip']}.join(',') %>
+zk_server_ip=<%= @servers.collect{|x| x['ipaddress']}.join(',') %>
 zk_server_port=2181
 listen_ip_addr=<%=node['contrail']['cfgm']['ip']%>
 listen_port=5998
 log_local=True
 log_file=/var/log/contrail/discovery.log
-cassandra_server_list = <%= @servers.collect{|x| x['contrail']['database']['ip']+':9160'}.join(' ') %>
+cassandra_server_list = <%= @servers.collect{|x| x['ipaddress']+':9160'}.join(' ') %>
 log_level=SYS_NOTICE
 
 # minimim time to allow client to cache service information (seconds)

--- a/cookbooks/contrail/templates/default/contrail-dns.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-dns.conf.erb
@@ -12,7 +12,7 @@
 # named_log_file=/var/log/named/bind.log   # named log file
 # rndc_config_file=rndc.conf               # rndc config file
 # rndc_secret=secretkey                    # rndc secret
-hostip = <%=node['contrail']['control']['ip']%>
+hostip = <%= node['ipaddress'] %>
 # hostname= # Retrieved as `hostname`
 # http_server_port=8092
 # dns_server_port=53
@@ -32,5 +32,5 @@ server =  <%=node['contrail']['cfgm']['ip']%>
 
 [IFMAP]
 certs_store=
-user = <%=node['contrail']['control']['ip']%>.dns
-password = <%=node['contrail']['control']['ip']%>.dns
+user = <%= node['ipaddress'] %>.dns
+password = <%= node['ipaddress'] %>.dns

--- a/cookbooks/contrail/templates/default/contrail-dns.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-dns.conf.erb
@@ -27,7 +27,7 @@ log_file = /var/log/contrail/contrail-dns.log
 # test_mode=0
 
 [DISCOVERY]
-server =  <%=node['contrail']['cfgm']['ip']%>
+server =  <%=node['ipaddress']%>
 #port = 5998
 
 [IFMAP]

--- a/cookbooks/contrail/templates/default/contrail-neutron-plugin.ini.erb
+++ b/cookbooks/contrail/templates/default/contrail-neutron-plugin.ini.erb
@@ -5,7 +5,7 @@ multi_tenancy = <%=node['contrail']['multi_tenancy']%>
 contrail_extensions = ipam:neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_ipam.NeutronPluginContrailIpam,policy:neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_policy.NeutronPluginContrailPolicy,route-table:neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_vpc.NeutronPluginContrailVpc,contrail:None
 
 [KEYSTONE]
-auth_url = <%=node['contrail']['protocol']['keystone']%>://<%=node['contrail']['keystone']['ip']%>:35357/v2.0
+auth_url = <%=node['contrail']['protocol']['keystone']%>://<%= @keystone_server_ip %>:35357/v2.0
 admin_user=<%=node['contrail']['admin_user']%>
 admin_password=<%=node['contrail']['admin_token']%>
 admin_token=<%=node['contrail']['admin_token']%>

--- a/cookbooks/contrail/templates/default/contrail-neutron-plugin.ini.erb
+++ b/cookbooks/contrail/templates/default/contrail-neutron-plugin.ini.erb
@@ -1,5 +1,5 @@
 [APISERVER]
-api_server_ip = <%=node['contrail']['cfgm']['ip']%>
+api_server_ip = <%=node['ipaddress']%>
 api_server_port = 8082
 multi_tenancy = <%=node['contrail']['multi_tenancy']%>
 contrail_extensions = ipam:neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_ipam.NeutronPluginContrailIpam,policy:neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_policy.NeutronPluginContrailPolicy,route-table:neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_vpc.NeutronPluginContrailVpc,contrail:None

--- a/cookbooks/contrail/templates/default/contrail-query-engine.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-query-engine.conf.erb
@@ -6,7 +6,7 @@
 
 [DEFAULT]
 # analytics_data_ttl=48
-  cassandra_server_list = <%= @servers.collect{|x| x['contrail']['database']['ip']+':9160'}.join(' ') %>
+  cassandra_server_list = <%= @servers.collect{|x| x['ipaddress']+':9160'}.join(' ') %>
   collectors=127.0.0.1:8086
   hostip = <%=node['contrail']['analytics']['ip']%>
 # log_category=

--- a/cookbooks/contrail/templates/default/contrail-query-engine.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-query-engine.conf.erb
@@ -8,7 +8,7 @@
 # analytics_data_ttl=48
   cassandra_server_list = <%= @servers.collect{|x| x['ipaddress']+':9160'}.join(' ') %>
   collectors=127.0.0.1:8086
-  hostip = <%=node['contrail']['analytics']['ip']%>
+  hostip = <%=node['ipaddress']%>
 # log_category=
 # log_disable=0
   log_file = /var/log/contrail/contrail-query-engine.log
@@ -23,5 +23,5 @@
 # port=5998
 
 [REDIS]
-  server = <%=node['contrail']['analytics']['ip']%>
+  server = <%=node['ipaddress']%>
   port = 6379

--- a/cookbooks/contrail/templates/default/contrail-query-engine.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-query-engine.conf.erb
@@ -19,7 +19,7 @@
 # test_mode=0
 
 [DISCOVERY]
-# server =  <%=node['contrail']['cfgm']['ip']%>
+# server =  <%=node['ipaddress']%>
 # port=5998
 
 [REDIS]

--- a/cookbooks/contrail/templates/default/contrail-schema.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-schema.conf.erb
@@ -9,7 +9,7 @@ ifmap_server_ip = <%=node['contrail']['cfgm']['ip']%>
 ifmap_server_port = 8445
 ifmap_username = schema-transformer
 ifmap_password = schema-transformer
-cassandra_server_list = <%= @servers.collect{|x| x['contrail']['database']['ip']+':9160'}.join(' ') %>
+cassandra_server_list = <%= @servers.collect{|x| x['ipaddress']+':9160'}.join(' ') %>
 api_server_ip=<%=node['contrail']['cfgm']['ip']%>
 api_server_port=8082
 log_file=/var/log/contrail/contrail-schema.log
@@ -17,7 +17,7 @@ log_local=1
 log_level=SYS_NOTICE
 disc_server_ip=<%=node['contrail']['cfgm']['ip']%>
 disc_server_port=5998
-zk_server_ip = <%= @servers.collect{|x| x['contrail']['database']['ip']+':2181'}.join(',') %>
+zk_server_ip = <%= @servers.collect{|x| x['ipaddress']+':2181'}.join(',') %>
 
 [SECURITY]
 use_certs=False

--- a/cookbooks/contrail/templates/default/contrail-schema.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-schema.conf.erb
@@ -5,17 +5,17 @@
 ################################################
 
 [DEFAULTS]
-ifmap_server_ip = <%=node['contrail']['cfgm']['ip']%>
+ifmap_server_ip = <%=node['ipaddress']%>
 ifmap_server_port = 8445
 ifmap_username = schema-transformer
 ifmap_password = schema-transformer
 cassandra_server_list = <%= @servers.collect{|x| x['ipaddress']+':9160'}.join(' ') %>
-api_server_ip=<%=node['contrail']['cfgm']['ip']%>
+api_server_ip=<%=node['ipaddress']%>
 api_server_port=8082
 log_file=/var/log/contrail/contrail-schema.log
 log_local=1
 log_level=SYS_NOTICE
-disc_server_ip=<%=node['contrail']['cfgm']['ip']%>
+disc_server_ip=<%=node['ipaddress']%>
 disc_server_port=5998
 zk_server_ip = <%= @servers.collect{|x| x['ipaddress']+':2181'}.join(',') %>
 

--- a/cookbooks/contrail/templates/default/contrail-svc-monitor.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-svc-monitor.conf.erb
@@ -33,7 +33,7 @@ analytics_server_ip=<%=node['contrail']['analytics']['ip']%>
 analytics_server_port=8081
 
 [KEYSTONE]
-auth_host=<%=node['contrail']['keystone']['ip']%>
+auth_host=<%= @keystone_server_ip %>
 auth_protocol=<%=node['contrail']['protocol']['keystone']%>
 auth_port=35357
 admin_user=<%=node['contrail']['admin_user']%>

--- a/cookbooks/contrail/templates/default/contrail-svc-monitor.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-svc-monitor.conf.erb
@@ -29,7 +29,7 @@ certfile=/etc/contrail/ssl/certs/svc_monitor.pem
 ca_certs=/etc/contrail/ssl/certs/ca.pem
 
 [SCHEDULER]
-analytics_server_ip=<%=node['contrail']['analytics']['ip']%>
+analytics_server_ip=<%=node['ipaddress']%>
 analytics_server_port=8081
 
 [KEYSTONE]

--- a/cookbooks/contrail/templates/default/contrail-svc-monitor.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-svc-monitor.conf.erb
@@ -5,21 +5,21 @@
 ################################################
 
 [DEFAULTS]
-ifmap_server_ip = <%=node['contrail']['cfgm']['ip']%>
+ifmap_server_ip = <%=node['ipaddress']%>
 ifmap_server_port = 8445
 ifmap_username = svc-monitor
 ifmap_password = svc-monitor
-api_server_ip = <%=node['contrail']['cfgm']['ip']%>
+api_server_ip = <%=node['ipaddress']%>
 api_server_port=8082
 zk_server_ip = <%= @servers.collect{|x| x['ipaddress']+':2181'}.join(',') %>
 log_file=/var/log/contrail/contrail-svc-monitor.log
 cassandra_server_list = <%= @servers.collect{|x| x['ipaddress']+':9160'}.join(' ') %>
-disc_server_ip = <%=node['contrail']['cfgm']['ip']%>
+disc_server_ip = <%=node['ipaddress']%>
 disc_server_port=5998
 region_name=<%=node['contrail']['region_name']%>
 log_local=1
 log_level=SYS_NOTICE
-rabbit_server=<%=node['contrail']['cfgm']['hostname']%>
+rabbit_server=<%=node['hostname']%>
 rabbit_port=5672
 
 [SECURITY]

--- a/cookbooks/contrail/templates/default/contrail-svc-monitor.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-svc-monitor.conf.erb
@@ -11,9 +11,9 @@ ifmap_username = svc-monitor
 ifmap_password = svc-monitor
 api_server_ip = <%=node['contrail']['cfgm']['ip']%>
 api_server_port=8082
-zk_server_ip = <%= @servers.collect{|x| x['contrail']['database']['ip']+':2181'}.join(',') %>
+zk_server_ip = <%= @servers.collect{|x| x['ipaddress']+':2181'}.join(',') %>
 log_file=/var/log/contrail/contrail-svc-monitor.log
-cassandra_server_list = <%= @servers.collect{|x| x['contrail']['database']['ip']+':9160'}.join(' ') %>
+cassandra_server_list = <%= @servers.collect{|x| x['ipaddress']+':9160'}.join(' ') %>
 disc_server_ip = <%=node['contrail']['cfgm']['ip']%>
 disc_server_port=5998
 region_name=<%=node['contrail']['region_name']%>

--- a/cookbooks/contrail/templates/default/contrail-vnc_api_lib.ini.erb
+++ b/cookbooks/contrail/templates/default/contrail-vnc_api_lib.ini.erb
@@ -16,7 +16,7 @@ BASE_URL = /
 ; Authentication settings (optional)
 [auth]
 AUTHN_TYPE = keystone
-AUTHN_SERVER = <%=node['contrail']['keystone']['ip']%>
+AUTHN_SERVER = <%= @keystone_server_ip %>
 AUTHN_PROTOCOL = <%=node['contrail']['protocol']['keystone']%>
 AUTHN_PORT = 35357
 AUTHN_URL = /v2.0/tokens

--- a/cookbooks/contrail/templates/default/contrail-vnc_api_lib.ini.erb
+++ b/cookbooks/contrail/templates/default/contrail-vnc_api_lib.ini.erb
@@ -7,7 +7,7 @@
 [global]
 ;WEB_SERVER = 127.0.0.1
 ;WEB_PORT = 9696  ; connection through quantum plugin
-WEB_SERVER = <%=node['contrail']['cfgm']['ip']%>
+WEB_SERVER = <%=node['ipaddress']%>
 WEB_PORT = 8082 ; connection to api-server directly
 
 BASE_URL = /

--- a/cookbooks/contrail/templates/default/contrail-vrouter-agent.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-vrouter-agent.conf.erb
@@ -57,7 +57,7 @@ log_level=SYS_INFO
 #mandatory. Else this section is optional
 
 # IP address of discovery server
-server=<%=node['contrail']['cfgm']['ip']%>
+server=<%=node['ipaddress']%>
 
 # Number of control-nodes info to be provided by Discovery service. Possible
 # values are 1 and 2

--- a/cookbooks/contrail/templates/default/haproxy.cfg.erb
+++ b/cookbooks/contrail/templates/default/haproxy.cfg.erb
@@ -43,7 +43,7 @@ backend contrail-api-backend
   @servers.each do |server|
     idx = idx + 1
 -%>
-    <%= "server #{server['contrail']['cfgm']['ip']} #{server['contrail']['cfgm']['ip']}:#{idx} check inter 2000 rise 2 fall 3" %>
+    <%= "server #{server['ipaddress']} #{server['ipaddress']}:#{idx} check inter 2000 rise 2 fall 3" %>
 <% end -%>
     #server  10.84.14.2 10.84.14.2:9100 check
     #server  10.84.14.2 10.84.14.2:9101 check
@@ -56,7 +56,7 @@ backend contrail-discovery-backend
   @servers.each do |server|
     idx = idx + 1
 -%>
-    <%= "server #{server['contrail']['cfgm']['ip']} #{server['contrail']['cfgm']['ip']}:#{idx} check inter 2000 rise 2 fall 3" %>
+    <%= "server #{server['ipaddress']} #{server['ipaddress']}:#{idx} check inter 2000 rise 2 fall 3" %>
 <% end -%>
 
     #server  10.84.14.2 10.84.14.2:9110 check
@@ -76,7 +76,7 @@ backend quantum-server-backend
   @servers.each do |server|
     idx = idx + 1
 -%>
-    <%= "server #{server['contrail']['cfgm']['ip']} #{server['contrail']['cfgm']['ip']}:#{idx} check inter 2000 rise 2 fall 3" %>
+    <%= "server #{server['ipaddress']} #{server['ipaddress']}:#{idx} check inter 2000 rise 2 fall 3" %>
 <% end -%>
 
 <% end -%>

--- a/cookbooks/contrail/templates/default/ifmap-basicauthusers.properties.erb
+++ b/cookbooks/contrail/templates/default/ifmap-basicauthusers.properties.erb
@@ -33,5 +33,5 @@ helper:mapclient
 
 # This is a read-only MAPC
 reader:reader
-<%=node['contrail']['control']['ip']%>:<%=node['contrail']['control']['ip']%>
-<%=node['contrail']['control']['ip']%>.dns:<%=node['contrail']['control']['ip']%>.dns
+<%=node['ipaddress']%>:<%=node['ipaddress']%>
+<%=node['ipaddress']%>.dns:<%=node['ipaddress']%>.dns

--- a/cookbooks/contrail/templates/default/rabbitmq-env.conf.erb
+++ b/cookbooks/contrail/templates/default/rabbitmq-env.conf.erb
@@ -1,3 +1,3 @@
 
-NODE_IP_ADDRESS=<%=node['contrail']['cfgm']['ip']%>
-NODENAME=rabbit@<%=node['contrail']['cfgm']['hostname']%>
+NODE_IP_ADDRESS=<%=node['ipaddress']%>
+NODENAME=rabbit@<%=node['hostname']%>

--- a/cookbooks/contrail/templates/default/rabbitmq.config.erb
+++ b/cookbooks/contrail/templates/default/rabbitmq.config.erb
@@ -1,6 +1,6 @@
 [
-   {rabbit, [ {tcp_listeners, [{"<%=node['contrail']['cfgm']['ip']%>", 5672}]}, {cluster_partition_handling, autoheal},{loopback_users, []},
-              {cluster_nodes, {[<%=node['contrail']['cfgm']['hostname']%>], disc}},
+   {rabbit, [ {tcp_listeners, [{"<%=node['ipaddress']%>", 5672}]}, {cluster_partition_handling, autoheal},{loopback_users, []},
+              {cluster_nodes, {[<%=node['hostname']%>], disc}},
               {vm_memory_high_watermark, 0.4},
               {disk_free_limit,50000000},
               {log_levels,[{connection, info},{mirroring, info}]},

--- a/cookbooks/contrail/templates/default/vrouter_nodemgr_param.erb
+++ b/cookbooks/contrail/templates/default/vrouter_nodemgr_param.erb
@@ -1,1 +1,1 @@
-DISCOVERY=<%=node['contrail']['cfgm']['ip']%>
+DISCOVERY=<%=node['ipaddress']%>

--- a/cookbooks/contrail/templates/default/zoo.cfg.erb
+++ b/cookbooks/contrail/templates/default/zoo.cfg.erb
@@ -21,13 +21,13 @@ dataDir=/var/lib/zookeeper
 
 # the port at which the clients will connect
 clientPort=2181
-clientPortBindAddress=<%=node['contrail']['database']['ip']%>
+clientPortBindAddress=<%=node['ipaddress']%>
 
 # specify all zookeeper servers
 # The first port is used by followers to connect to the leader
 # The second one is used for leader election
 <% @servers.each do |server| -%>
-<%= "server.#{server['contrail']['node_number']}=#{server['contrail']['database']['ip']}:2888:3888" %>
+<%= "server.#{server['contrail']['node_number']}=#{server['ipaddress']}:2888:3888" %>
 <% end -%>
 
 # To avoid seeks ZooKeeper allocates space in the transaction log file in


### PR DESCRIPTION
This change removes a number of IP address and hostname attributes. In their
place are either Ohai attributes or functions to query the chef server for
nodes with a given role.

The attributes removed are,
- default['contrail']['cfgm']['hostname'] = "a6s35"
- default['contrail']['cfgm']['ip'] = "10.84.13.35"
- default['contrail']['keystone']['ip'] = "10.84.13.35"
- default['contrail']['database']['ip'] = "10.84.13.35"
- default['contrail']['control']['ip'] = "10.84.13.35"
- default['contrail']['control']['hostname'] = "a6s35"
- default['contrail']['analytics']['ip'] = "10.84.13.35"

The reason for this change is to do away with the need to populate these
attributes before running chef-client. Having the recipe discover this
information makes the cookbook more flexible and easy to use.
