### PR TITLE
Fix references to controller node IP

### DIFF
--- a/cookbooks/contrail/libraries/utils.rb
+++ b/cookbooks/contrail/libraries/utils.rb
@@ -68,4 +68,15 @@ module ::Contrail
     controller_nodes.first["ipaddress"]
   end
 
+  def get_interface_address(interface)
+    if node["network"]['interfaces'].key?(interface)
+      node["network"]['interfaces'][interface]['addresses'].each do |ip, params|
+        if params['family'] == 'inet'
+          return ip
+        end
+      end
+    end
+    nil
+  end
+
 end

--- a/cookbooks/contrail/metadata.rb
+++ b/cookbooks/contrail/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'praneetb@juniper.net'
 license          'All rights reserved'
 description      'Installs/Configures contrail'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.0'
+version          '0.4.0'
 
 depends          'yum', '>= 3.0.0'

--- a/cookbooks/contrail/recipes/cfgm.rb
+++ b/cookbooks/contrail/recipes/cfgm.rb
@@ -181,7 +181,7 @@ get_compute_nodes.each do |server|
         hostname=server['hostname']
         hostip=server['ipaddress']
         cfgm_ip=node['ipaddress']
-        openstack_ip=get_openstack_controller_node_ip
+        openstack_ip=openstack_controller_node_ip
         code <<-EOH
             python /opt/contrail/utils/provision_vrouter.py \
                 --admin_user #{admin_user} \

--- a/cookbooks/contrail/templates/default/contrail-vrouter-agent.conf.erb
+++ b/cookbooks/contrail/templates/default/contrail-vrouter-agent.conf.erb
@@ -57,7 +57,7 @@ log_level=SYS_INFO
 #mandatory. Else this section is optional
 
 # IP address of discovery server
-server=<%=node['ipaddress']%>
+server=<%= @contrail_controller_node_ip %>
 
 # Number of control-nodes info to be provided by Discovery service. Possible
 # values are 1 and 2

--- a/cookbooks/contrail/templates/default/vrouter_nodemgr_param.erb
+++ b/cookbooks/contrail/templates/default/vrouter_nodemgr_param.erb
@@ -1,1 +1,1 @@
-DISCOVERY=<%=node['ipaddress']%>
+DISCOVERY=<%= @contrail_controller_node_ip %>


### PR DESCRIPTION
Two templates were using the compute nodes IP address rather then the
contrail controller node address. This change passes the correct IP
into these templates.

If an IP address isn't specified for the vhost0 physical interface then
look it up in Chef.
